### PR TITLE
Fix/registration error message#8

### DIFF
--- a/app/assets/stylesheets/users/sign_up.scss
+++ b/app/assets/stylesheets/users/sign_up.scss
@@ -40,8 +40,8 @@
   border-radius: 10px;
 }
 // エラーメッセージ
-.error_messages{
-
+.error_messages .alert{
+  padding: 0.5rem 1rem;
 }
 
 // ログイン画面

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,10 @@ class User < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i
+  validates :email, uniqueness: true, format: { with: VALID_EMAIL_REGEX, message: "を○○@○○.○○の形式で入力して下さい" }, length: { maximum: 255 }
+  validates :nickname, presence: true, length: { in: 2..20 }
+  VALID_PASSWORD_REGEX = /\A(?=.*[a-z])(?=.*\d)[a-z\d]{8,}+\z/
+  validates :password, length: { maximum: 75 }, format: { with: VALID_PASSWORD_REGEX, message: "を半角英数字8文字以上で入力して下さい" }
 end

--- a/app/views/tickets/new.html.erb
+++ b/app/views/tickets/new.html.erb
@@ -1,6 +1,5 @@
 <%= render partial: 'shared/header' %>
 
-
 <%= form_for(@ticket) do |f| %>
   <div class="container listing-container">
     <div class="wrapper form-group">

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,15 +4,15 @@
   <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
     <h2 class="heading">新規会員登録</h2>
     <div class="wrapper form-group">
-      <%= devise_error_messages! %>
-      <% if flash[:alert] %>
+
+      <%# エラーメッセージ %>
+      <% if resource.errors.full_messages.any? %>
         <div class="error_messages">
-          <% flash.each do |key, value| %>
-            <%= content_tag :div, value, class: "#{key} alert-danger" %>
+          <% resource.errors.full_messages.each do |error_message| %>
+            <%= content_tag :div, error_message, class:"alert alert-danger" %>
           <% end %>
         </div>
       <% end %>
-
 
       <%= f.label :nickname, "ニックネーム" %>
       <%= f.text_field :nickname, class: "form-control", autofocus: true %>


### PR DESCRIPTION
close https://github.com/shun0211/live_share/issues/8

# 概要
新規登録画面でログイン画面で出ているのと同様のエラーメッセージが表示される。
<br>

# この修正が正しい理由
新規登録フォームを空にして送信ボタンを押すと、ログイン画面と同様のエラーメッセージが表示されるため。
<br>
