### PR TITLE
Feat/message index#59

### DIFF
--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -2,6 +2,7 @@
 
 .message-container{
   display: flex;
+  height: calc(100vh - 70px);
   .side-bar{
     background-color: $boundary_primary;
     width: 25%;
@@ -13,6 +14,7 @@
   }
   .avatar{
     border-radius: 100%;
+    display: block;
   }
   .wrapper{
     background-color: none;
@@ -41,12 +43,13 @@
     background-color: #89B8ff;
     padding: 0 1% 7px;
     border-radius: 0 0 5px 5px;
-    min-height: calc(100vh - 70px);
+    overflow: auto;
+    height: calc(100vh - 70px - 32px);
   }
   #messages{
     min-height: 80vh;
   }
-  .massage{
+  .message{
     display: flex;
     padding: 6px 0 6px;
   }
@@ -95,6 +98,9 @@
     border-left: 8px solid #68FF68;
     border-top: 6px solid transparent;
     border-bottom: 4px solid transparent;
+  }
+  .pagination{
+    display: none;
   }
   .message-form{
     position: relative;

--- a/app/assets/stylesheets/rooms.scss
+++ b/app/assets/stylesheets/rooms.scss
@@ -5,6 +5,7 @@
   .side-bar{
     background-color: $boundary_primary;
     width: 25%;
+    min-height: calc(100vh - 70px);
   }
   .user-info{
     display: flex;
@@ -26,6 +27,11 @@
     overflow: hidden;
     height: 1rem;
   }
+  .attention{
+    color: $dark_gray;
+    padding: 20px 15px;
+
+  }
   // メッセージ画面
   main{
     width: 75%;
@@ -35,6 +41,7 @@
     background-color: #89B8ff;
     padding: 0 1% 7px;
     border-radius: 0 0 5px 5px;
+    min-height: calc(100vh - 70px);
   }
   #messages{
     min-height: 80vh;

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -2,7 +2,12 @@ class RoomsController < ApplicationController
   def index
     @rooms = current_user.rooms.includes(:messages).order("messages.created_at DESC")
     @active_room = @rooms.first
-    @messages = @active_room.messages
+    @messages = @active_room.messages.order("created_at DESC").paginate(page: params[:page], per_page: 30)
+    gon.current_user_id = current_user.id
+    respond_to do |format|
+      format.html
+      format.json
+    end
   end
 
   def create
@@ -17,7 +22,7 @@ class RoomsController < ApplicationController
     @room = Room.find(params[:id])
     @rooms = current_user.rooms
     @user = @room.users.where.not(id: current_user.id)
-    @messages = @room.messages
+    @messages = @room.messages.paginate(page: params[:page], per_page: 30)
   end
 
 end

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,7 +1,8 @@
 class RoomsController < ApplicationController
   def index
-    @rooms = current_user.rooms.joins(:messages).order("messages.created_at DESC")
+    @rooms = current_user.rooms.includes(:messages).order("messages.created_at DESC")
     @active_room = @rooms.first
+    @messages = @active_room.messages
   end
 
   def create
@@ -14,24 +15,8 @@ class RoomsController < ApplicationController
 
   def show
     @room = Room.find(params[:id])
-    # ログイン中のユーザの持つentriesテーブルの全レコード
-    @my_entries = Entry.where(user_id: current_user.id)
-    # ログイン中のユーザが持つすべてのroom_id取得
-    my_room = []
-    @my_entries.each do |my_entry|
-      my_room << my_entry.room_id
-    end
-    # ログインユーザと同じ部屋を持つユーザのentriesテーブルの全レコード
-    @partner_entries = Entry.where(room_id: my_room)
-    # 同じ部屋を持つユーザのidを配列に格納
-    partner_id = []
-    @partner_entries.each do |partner_entry|
-      partner_id << partner_entry.user_id
-    end
-    @users = User.where(id: partner_id).where.not(id: current_user.id)
-    # ログイン中のユーザが入っているすべてのRoom
-    @my_rooms = Room.where(id: my_room)
-    @partner = Entry.where(room_id: params[:id]).where.not(user_id: current_user.id)
+    @rooms = current_user.rooms
+    @user = @room.users.where.not(id: current_user.id)
     @messages = @room.messages
   end
 

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -1,4 +1,9 @@
 class RoomsController < ApplicationController
+  def index
+    @rooms = current_user.rooms.joins(:messages).order("messages.created_at DESC")
+    @active_room = @rooms.first
+  end
+
   def create
     @room = Room.create
     @entry_own = Entry.create(room_id: @room.id, user_id: current_user.id)

--- a/app/javascript/channels/room_channel.js
+++ b/app/javascript/channels/room_channel.js
@@ -28,4 +28,45 @@ $(document).on('turbolinks:load', function(){
       return this.perform('speak', {message: message});
     }
   });
+
+  function buildMessageHTML(messages){
+    for(let i=0; i<30; i++){
+      if(gon.current_user_id === messages[i].user_id){
+        let html = `<div class="message">
+                      <img alt="ユーザのプロフィール画像" class="avatar" src="/assets/${messages[i].user.avatar}" width="40" height="40">
+                      <div class="speech-bubble-own">
+                        ${messages[i].content}
+                      </div>
+                    </div>`
+        document.getElementById('messages').insertAdjacentHTML('afterbegin', html)
+      }else{
+        let html = `<div class="message">
+                      <img alt="ユーザのプロフィール画像" class="avatar" src="/assets/${messages[i].user.avatar}" width="40" height="40">
+                      <div class="speech-bubble-partner">
+                        ${messages[i].content}
+                      </div>
+                    </div>`
+        document.getElementById('messages').insertAdjacentHTML('afterbegin', html)
+      }
+    }
+  }
+
+  function scrollToBottom(){
+    let messageScreenHeight = $(".message-wrapper")[0].scrollHeight;
+    $(".message-wrapper").scrollTop(messageScreenHeight);
+  };
+  scrollToBottom();
+  $(".message-wrapper").scroll(function(){
+    if ($('.message-wrapper').scrollTop() === 0){
+      let url = $(".message-wrapper").find('.pagination .next_page a').attr("href");
+      $.ajax({
+        url: url,
+        type: "GET",
+        dataType: "json"
+      })
+      .done(function(messages){
+        buildMessageHTML(messages);
+      });
+    };
+  })
 });

--- a/app/javascript/channels/room_channel.js
+++ b/app/javascript/channels/room_channel.js
@@ -30,7 +30,9 @@ $(document).on('turbolinks:load', function(){
   });
 
   function buildMessageHTML(messages){
-    for(let i=0; i<30; i++){
+    let messageNum = Object.keys(messages).length
+    console.log(messageNum);
+    for(let i=0; i<messageNum; i++){
       if(gon.current_user_id === messages[i].user_id){
         let html = `<div class="message">
                       <img alt="ユーザのプロフィール画像" class="avatar" src="/assets/${messages[i].user.avatar}" width="40" height="40">
@@ -56,17 +58,46 @@ $(document).on('turbolinks:load', function(){
     $(".message-wrapper").scrollTop(messageScreenHeight);
   };
   scrollToBottom();
+  let i = 1;
   $(".message-wrapper").scroll(function(){
+    let messageScreenHeight = $(".message-wrapper")[0].scrollHeight;
     if ($('.message-wrapper').scrollTop() === 0){
-      let url = $(".message-wrapper").find('.pagination .next_page a').attr("href");
-      $.ajax({
-        url: url,
-        type: "GET",
-        dataType: "json"
-      })
-      .done(function(messages){
-        buildMessageHTML(messages);
-      });
+      let nextPageNum = parseInt($(".message-wrapper").find('.pagination .next_page a').attr("href").match(/\d/), 10);
+      if (nextPageNum > i){
+        let url = "/rooms?page=" + nextPageNum
+        console.log(url);
+        $.ajax({
+          url: url,
+          type: "GET",
+          dataType: "json"
+        })
+        .done(function(messages){
+          console.log(messages);
+          buildMessageHTML(messages);
+          let messagePosition = $(".message-wrapper")[0].scrollHeight - messageScreenHeight;
+          console.log(messagePosition);
+          $('.message-wrapper').scrollTop(messagePosition);
+          i = parseInt(messages[0].page, 10);
+          console.log(i);
+        });
+      }else{
+        nextPageNum = i + 1;
+        let url = "/rooms?page=" + nextPageNum
+        console.log(url);
+        $.ajax({
+          url: url,
+          type: "GET",
+          dataType: "json"
+        })
+        .done(function(messages){
+          console.log(messages);
+          buildMessageHTML(messages);
+          let messagePosition = $(".message-wrapper")[0].scrollHeight - messageScreenHeight;
+          console.log(messagePosition);
+          $('.message-wrapper').scrollTop(messagePosition);
+          i = parseInt(messages[0].page, 10);
+        });
+      }
     };
   })
 });

--- a/app/javascript/detail.js
+++ b/app/javascript/detail.js
@@ -2,7 +2,7 @@ $(function(){
   function buildHTML(comment){
     const html = `<div class="post" data-comment-id="${comment.id}">
                     <div class="post-info">
-                      <img alt="コメント投稿者のプロフィール画像" class="icon" src="${comment.userAvatar}" width="35" height="35">
+                      <img alt="コメント投稿者のプロフィール画像" class="icon" src="/assets/${comment.userAvatar}" width="35" height="35">
                       <div class="post-user">
                         ${comment.userNickname}
                       </div>
@@ -37,6 +37,7 @@ $(function(){
     })
     .done(function(comment){
       const commentHTML = buildHTML(comment);
+
       $('.posts').append(commentHTML);
       document.getElementById("comment_content").value = "";
       document.getElementById("empty-message").remove();

--- a/app/models/room.rb
+++ b/app/models/room.rb
@@ -1,4 +1,5 @@
 class Room < ApplicationRecord
   has_many :messages
   has_many :entries
+  has_many :users, through: :entries
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -7,7 +7,7 @@ class Ticket < ApplicationRecord
   has_many :requests
   has_many :notifications, dependent: :destroy
   belongs_to :seller, class_name: "User", foreign_key: 'seller_id'
-  belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id'
+  belongs_to :buyer, class_name: "User", foreign_key: 'buyer_id', optional: true
 
   def liked_by(user)
     likes.where(user_id: user.id).exists?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,6 +10,7 @@ class User < ApplicationRecord
   has_many :likes
   has_many :messages
   has_many :entries
+  has_many :rooms, through: :entries
   has_many :requests
   has_many :active_notifications, class_name: 'Notification', foreign_key: 'visitor_id'
   has_many :passive_notifications, class_name: 'Notification', foreign_key: 'visited_id'

--- a/app/views/messages/_message.html.erb
+++ b/app/views/messages/_message.html.erb
@@ -1,4 +1,4 @@
-<div class="massage">
+<div class="message">
   <% if message.user.id === current_user.id %>
     <div class="speech-bubble-own">
       <%= message.content %>

--- a/app/views/rooms/_sidebar.html.erb
+++ b/app/views/rooms/_sidebar.html.erb
@@ -1,0 +1,59 @@
+<div class="side-bar">
+    <% if @rooms.present? %>
+      <% @rooms.each do |room| %>
+        <% room.users.each do |user| %>
+          <% unless user.id === current_user.id %>
+            <div class="user-info">
+              <%= image_tag user.avatar.url, alt: "ユーザのプロフィール画像", class: "avatar", size: "40" %>
+              <div class="wrapper">
+                <div class="user-name">
+                  <%= user.nickname %>
+                </div>
+                <div class="last-message">
+                  <% if room.messages.present? %>
+                    <%= room.messages.order(created_at: :desc).take.content %>
+                  <% end %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p class="attention">まだメッセージをしているユーザはいません。</p>
+    <% end %>
+  </div>
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+<%# <div class="side-bar">
+    <% @my_rooms.each do |my_room| %>
+      <%# <% @users.each do |user| %>
+        <%# <div class="user-info"> %>
+          <%# <%= image_tag user.avatar.url, alt: "ユーザのプロフィール画像", class: "avatar", size: "40" %>
+          <%# <div class="wrapper"> %>
+            <%# <div class="user-name"> %>
+              <%# <%= user.nickname %>
+            <%# </div> %>
+            <%# <div class="last-message"> %>
+              <%# <% if my_room.messages.present? %>
+                <%# <%= my_room.messages.order(created_at: :desc).take.content %>
+              <%# <% end %>
+            <%# </div> %>
+          <%# </div> %>
+        <%# </div> %>
+      <%# <% end %>
+    <%# <% end %>
+  <%# </div> %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,0 +1,54 @@
+<%= render "shared/header" %>
+<div class="message-container">
+  <div class="side-bar">
+    <% if @rooms.present? %>
+      <% @rooms.each do |room| %>
+        <% room.users.each do |user| %>
+          <% unless user.id === current_user.id %>
+            <div class="user-info">
+              <%= image_tag user.avatar.url, alt: "ユーザのプロフィール画像", class: "avatar", size: "40" %>
+              <div class="wrapper">
+                <div class="user-name">
+                  <%= user.nickname %>
+                </div>
+                <div class="last-message">
+                  <%= room.messages.order(created_at: :desc).take.content %>
+                </div>
+              </div>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    <% else %>
+      <p class="attention">まだメッセージをしているユーザはいません。</p>
+    <% end %>
+  </div>
+  <main>
+    <% if @rooms.present? %>
+      <% @active_room.users.each do |user| %>
+        <% unless user.id === current_user.id %>
+          <div class="partner">
+            <%= user.nickname %>
+          </div>
+          <div class="message-wrapper form-group">
+            <div id="messages" data-room_id="<%= @rooms[0].id %>">
+              <%= render @messages %>
+            </div>
+          <div class="message-form">
+            <i class="fas fa-image"></i>
+            <%= text_field_tag :content, nil, data: {behavior: 'form_data'}, class: "form-control" %>
+            <i class="far fa-paper-plane" data-behavior="room_speaker"></i>
+          </div>
+        <% end %>
+      <% end %>
+    <% else %>
+      <div class="partner">
+      </div>
+      <div class="message-wrapper">
+      </div>
+    <% end %>
+  </main>
+</div>
+
+<%= render "shared/sub_footer" %>
+<%= render "shared/footer" %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -1,28 +1,6 @@
 <%= render "shared/header" %>
 <div class="message-container">
-  <div class="side-bar">
-    <% if @rooms.present? %>
-      <% @rooms.each do |room| %>
-        <% room.users.each do |user| %>
-          <% unless user.id === current_user.id %>
-            <div class="user-info">
-              <%= image_tag user.avatar.url, alt: "ユーザのプロフィール画像", class: "avatar", size: "40" %>
-              <div class="wrapper">
-                <div class="user-name">
-                  <%= user.nickname %>
-                </div>
-                <div class="last-message">
-                  <%= room.messages.order(created_at: :desc).take.content %>
-                </div>
-              </div>
-            </div>
-          <% end %>
-        <% end %>
-      <% end %>
-    <% else %>
-      <p class="attention">まだメッセージをしているユーザはいません。</p>
-    <% end %>
-  </div>
+  <%= render partial: "sidebar" %>
   <main>
     <% if @rooms.present? %>
       <% @active_room.users.each do |user| %>

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -10,7 +10,7 @@
           </div>
           <div class="message-wrapper form-group">
             <div id="messages" data-room_id="<%= @rooms[0].id %>">
-              <%= render @messages %>
+              <%= render @messages.sort %>
             </div>
             <%= will_paginate(@messages) %>
           <div class="message-form">

--- a/app/views/rooms/index.html.erb
+++ b/app/views/rooms/index.html.erb
@@ -12,6 +12,7 @@
             <div id="messages" data-room_id="<%= @rooms[0].id %>">
               <%= render @messages %>
             </div>
+            <%= will_paginate(@messages) %>
           <div class="message-form">
             <i class="fas fa-image"></i>
             <%= text_field_tag :content, nil, data: {behavior: 'form_data'}, class: "form-control" %>

--- a/app/views/rooms/index.json.jbuilder
+++ b/app/views/rooms/index.json.jbuilder
@@ -1,0 +1,9 @@
+json.array! @messages do |message|
+  json.id message.id
+  json.user_id message.user_id
+  json.created_at message.created_at
+  json.content message.content
+  json.user do
+    json.avatar message.user.avatar.url
+  end
+end

--- a/app/views/rooms/index.json.jbuilder
+++ b/app/views/rooms/index.json.jbuilder
@@ -1,4 +1,5 @@
 json.array! @messages do |message|
+  json.page params[:page]
   json.id message.id
   json.user_id message.user_id
   json.created_at message.created_at

--- a/app/views/rooms/show.html.erb
+++ b/app/views/rooms/show.html.erb
@@ -1,26 +1,9 @@
 <%= render "shared/header" %>
 <div class="message-container">
-  <div class="side-bar">
-    <% @my_rooms.each do |my_room| %>
-      <% @users.each do |user| %>
-        <div class="user-info">
-          <%= image_tag user.avatar.url, alt: "ユーザのプロフィール画像", class: "avatar", size: "40" %>
-          <div class="wrapper">
-            <div class="user-name">
-              <%= user.nickname %>
-            </div>
-            <div class="last-message">
-              <%# ルームでした最後のメッセージが表示される必要がある。 %>
-              <%= my_room.messages.order(created_at: :desc).take.content %>
-            </div>
-          </div>
-        </div>
-      <% end %>
-    <% end %>
-  </div>
+  <%= render partial: "sidebar" %>
   <main>
     <div class="partner">
-      <%= @partner[0].user.nickname %>
+      <%= @user[0].nickname %>
     </div>
     <div class="message-wrapper form-group">
       <div id="messages" data-room_id="<%= @room.id %>">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -3,17 +3,23 @@
   <nav>
     <ul class="top-nav">
       <li><i class="fas fa-search"></i></li>
-      <li class="bell">
-        <%= link_to notifications_path do %>
-          <% if unchecked_notifications.any? %>
-            <i class="far fa-bell"></i>
-            <i class="fas fa-circle"></i>
-          <% else %>
-            <i class="far fa-bell"></i>
+      <% if user_signed_in? %>
+        <li class="bell">
+          <%= link_to notifications_path do %>
+            <% if unchecked_notifications.any? %>
+              <i class="far fa-bell"></i>
+              <i class="fas fa-circle"></i>
+            <% else %>
+              <i class="far fa-bell"></i>
+            <% end %>
           <% end %>
-        <% end %>
-      </li>
-      <li><i class="far fa-envelope"></i></li>
+        </li>
+        <li>
+          <%= link_to rooms_path do %>
+            <i class="far fa-envelope"></i>
+          <% end %>
+        </li>
+      <% end %>
       <li><label for="hamburger-menu" class="open"><i class="fas fa-bars"></i></label></li>
     </ul>
   </nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
 
   resources :notifications, only: :index
 
-  resources :rooms, only: [:create, :show]
+  resources :rooms, only: [:create, :show, :index]
 
   root 'homes#index'
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -67,3 +67,20 @@ Ticket.create!(
     seller_id: 1
   )
 end
+
+Room.create!
+Entry.create!(
+  user_id: 1,
+  room_id: 1
+)
+Entry.create!(
+  user_id: 2,
+  room_id: 1
+)
+100.times do |n|
+  Message.create!(
+    user_id: 2,
+    room_id: 1,
+    content: "Hello, World"
+  )
+end


### PR DESCRIPTION
close #59 

# 概要
メッセージ一覧画面作成

# この修正が正しい理由
- メッセージ一覧画面が表示される。
- サイドバーのユーザが直近でメッセージをした順に上から表示される。
- 新着メッセージが30件表示され、上へスクロールすると次の30件が表示される。
