### PR TITLE
Feat/message notification#109

### DIFF
--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -11,5 +11,6 @@ class RoomChannel < ApplicationCable::Channel
 
   def speak(data)
     Message.create!(content: data['message'], user_id: current_user.id, room_id: params[:room])
+    message = Message.where(room_id: params[:room]).order('created_at DESC').take
   end
 end

--- a/app/channels/room_channel.rb
+++ b/app/channels/room_channel.rb
@@ -12,5 +12,7 @@ class RoomChannel < ApplicationCable::Channel
   def speak(data)
     Message.create!(content: data['message'], user_id: current_user.id, room_id: params[:room])
     message = Message.where(room_id: params[:room]).order('created_at DESC').take
+    partner = Room.find(params[:room]).users.where.not(id: current_user.id)
+    Notification.create!(visitor_id: current_user.id, visited_id: partner[0].id, action: 'message', message_id: message.id)
   end
 end

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -3,6 +3,7 @@
 class Message < ApplicationRecord
   belongs_to :user
   belongs_to :room
+  has_one :notification
 
   validates :content, presence: true
   after_create_commit { MessageBroadcastJob.perform_later self }

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -6,4 +6,5 @@ class Notification < ApplicationRecord
   belongs_to :comment, optional: true
   belongs_to :visitor, class_name: 'User'
   belongs_to :visited, class_name: 'User'
+  belongs_to :message, optional: true
 end

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -46,6 +46,14 @@
                 <%= link_to "#{notification.visitor.nickname}", user_path(notification.visitor.id) %>さんから<%= link_to "あなたのチケット", ticket_path(notification.ticket_id) %>に購入希望がありました。
               </p>
               <hr>
+            <% when "message" then %>
+              <p class="content">
+                <%= link_to "#{notification.visitor.nickname}", user_path(notification.visitor.id) %>さんからあなたに<%= link_to "メッセージ", room_path(notification.message.room.id) %>がありました。
+              </p>
+              <p class="info">
+                <%= notification.message.content %>
+              </p>
+              <hr>
             <% end %>
           </div>
         <% end %>

--- a/db/migrate/20201212231359_change_column_to_notification.rb
+++ b/db/migrate/20201212231359_change_column_to_notification.rb
@@ -1,0 +1,5 @@
+class ChangeColumnToNotification < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :notifications, :message, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_12_09_111031) do
+ActiveRecord::Schema.define(version: 2020_12_12_231359) do
 
   create_table "comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
     t.string "content", null: false
@@ -61,6 +61,8 @@ ActiveRecord::Schema.define(version: 2020_12_09_111031) do
     t.boolean "checked", default: false, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "message_id"
+    t.index ["message_id"], name: "index_notifications_on_message_id"
   end
 
   create_table "requests", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci", force: :cascade do |t|
@@ -119,6 +121,7 @@ ActiveRecord::Schema.define(version: 2020_12_09_111031) do
   add_foreign_key "likes", "users"
   add_foreign_key "messages", "rooms"
   add_foreign_key "messages", "users"
+  add_foreign_key "notifications", "messages"
   add_foreign_key "requests", "tickets"
   add_foreign_key "requests", "users"
   add_foreign_key "tickets", "users", column: "buyer_id"


### PR DESCRIPTION
close #109 

# 概要
メッセージ送信の通知機能実装

# この修正が正しい理由
`bin/rspec spec/system/notifications_spec.rb`でテストが通過する。