### PR TITLE
購入機能の通知機能実装

### DIFF
--- a/app/controllers/tickets_controller.rb
+++ b/app/controllers/tickets_controller.rb
@@ -79,6 +79,7 @@ class TicketsController < ApplicationController
     ticket.buyer_id = taker.id
     ticket.save!
     flash[:notice] = "#{taker.nickname}さんに譲る処理が完了しました。"
+    ticket.create_notification_purchase(current_user)
     redirect_to ticket_path(ticket)
   end
 

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -48,6 +48,16 @@ class Ticket < ApplicationRecord
     notification.save!
   end
 
+  def create_notification_purchase(current_user)
+    notification = Notification.new(
+      visitor_id: current_user.id,
+      visited_id: buyer_id,
+      ticket_id: id,
+      action: 'purchase'
+    )
+    notification.save!
+  end
+
   validates :thumbnail, presence: true
   validates :event_name, presence: true, length: { maximum: 30 }
   validates :event_date, presence: true

--- a/app/views/notifications/index.html.erb
+++ b/app/views/notifications/index.html.erb
@@ -39,6 +39,11 @@
                 <%= notification.message.content %>
               </p>
               <hr>
+            <% when "purchase" then %>
+              <p class="content">
+                <%= link_to "#{notification.visitor.nickname}", user_path(notification.visitor.id) %>さんから<%= link_to "#{notification.ticket.event_name}のチケット", ticket_path(notification.ticket.id) %>の譲り先に選ばれました。
+              </p>
+              <hr>
             <% end %>
           </div>
         <% end %>


### PR DESCRIPTION
close #125 

# 概要
購入機能の通知機能実装

# この修正が正しい理由
ユーザがチケットに購入希望をクリックした後にチケット出品者が譲るボタンを押した場合、ユーザに選ばれたという通知が届く。
